### PR TITLE
Fix: 修复1.12版本Mod导致快捷栏透明度失效的问题

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,43 +1,80 @@
 buildscript {
     repositories {
-        jcenter()
-        maven { url = "http://files.minecraftforge.net/maven" }
+        maven { url = "https://maven.minecraftforge.net/" }
+        mavenCentral()
     }
+
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        classpath group: "net.minecraftforge.gradle", name: "ForgeGradle", version: "6.0.+"
     }
 }
-apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "1.0.2"
-group = "com.github.tartaricacid"
-archivesBaseName = "extraplayerrenderer"
+apply plugin: "java"
+apply plugin: "net.minecraftforge.gradle"
 
-sourceCompatibility = targetCompatibility = '1.8'
+version = '1.0.3'
+group = 'com.github.tartaricacid'
+archivesBaseName = 'extraplayerrenderer'
+
+java.toolchain.languageVersion = JavaLanguageVersion.of(8)
 compileJava {
-    sourceCompatibility = targetCompatibility = '1.8'
+    sourceCompatibility = "8"
+    targetCompatibility = "8"
+}
+
+repositories {
+    maven {
+        url = "https://maven.minecraftforge.net/"
+    }
 }
 
 minecraft {
-    version = "1.12.2-14.23.5.2768"
-    runDir = "run"
-    mappings = "stable_39"
-    replace "@VERSION@", project.version
+    mappings channel: "stable", version: "39-1.12"
+    runs {
+        client {
+            workingDirectory project.file('run')
+            property 'forge.logging.markers', 'REGISTRIES'
+            property 'forge.logging.console.level', 'debug'
+            property 'forge.enabledGameTestNamespaces', 'extraplayerrenderer'
+            mods {
+                extraplayerrenderer {
+                    source sourceSets.main
+                }
+            }
+        }
+
+        server {
+            workingDirectory project.file('run')
+            property 'forge.logging.markers', 'REGISTRIES'
+            property 'forge.logging.console.level', 'debug'
+            property 'forge.enabledGameTestNamespaces', 'extraplayerrenderer'
+            mods {
+                extraplayerrenderer {
+                    source sourceSets.main
+                }
+            }
+        }
+
+        data {
+            workingDirectory project.file('run')
+            property 'forge.logging.markers', 'REGISTRIES'
+            property 'forge.logging.console.level', 'debug'
+            args '--mod', 'extraplayerrenderer', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+            mods {
+                extraplayerrenderer {
+                    source sourceSets.main
+                }
+            }
+        }
+    }
 }
+
+sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 dependencies {
+    minecraft "net.minecraftforge:forge:1.12.2-14.23.5.2860"
 }
 
-processResources {
-    inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft.version
-
-    from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
-        expand 'version':project.version, 'mcversion':project.minecraft.version
-    }
-        
-    from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
-    }
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Sep 14 12:28:28 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip

--- a/src/main/java/com/github/tartaricacid/extraplayerrenderer/event/RenderScreen.java
+++ b/src/main/java/com/github/tartaricacid/extraplayerrenderer/event/RenderScreen.java
@@ -11,6 +11,7 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
+import org.lwjgl.opengl.GL11;
 
 @Mod.EventBusSubscriber(value = Side.CLIENT)
 public class RenderScreen {
@@ -26,6 +27,8 @@ public class RenderScreen {
         }
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayerSP player = mc.player;
+
+        boolean blendEnabled = GL11.glIsEnabled(GL11.GL_BLEND);
 
         GlStateManager.enableColorMaterial();
         GlStateManager.enableDepth();
@@ -50,6 +53,12 @@ public class RenderScreen {
         GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
         GlStateManager.disableTexture2D();
         GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
+
+        if (blendEnabled) {
+            GlStateManager.enableBlend();
+        } else {
+            GlStateManager.disableBlend();
+        }
     }
 
     public static float getScale() {


### PR DESCRIPTION
### 修复的问题
1.12版本的Mod实现会导致带有透明度的快捷栏透明度失效，透明部分会变为纯黑色。
### **改动说明**
通过记录渲染额外玩家实体前的blender函数状态并在渲染完成后恢复，确认修复了该bug。
由于1.12版本的gradle配置当前已不再兼容，升级了gradle版本。